### PR TITLE
copy over overview .md files from .github-private

### DIFF
--- a/docs/overview/appl-example.md
+++ b/docs/overview/appl-example.md
@@ -1,0 +1,20 @@
+# Application Examples
+
+## Purpose
+
+Here you can find an overview about the application examples offered in our SIMATIC AX GitHub Community. 
+
+This application example can be used for:
+
+- idea creation
+- usage of some example libraries
+
+## Overview of all application example
+
+[all application examples](https://github.com/search?q=topic%3Aapplication-example+org%3Asimatic-ax+fork%3Atrue&type=repositories)
+
+| Application Name | Description |
+|-|-|
+| [ae-sortingline](https://github.com/simatic-ax/ae-sortingline)   | Application example for a sorting line for items on a conveyor belt. In this example the usage of the [windowtracking library](https://github.com/simatic-ax/windowtracking) is shown. |
+| [ae-trafficlight](https://github.com/simatic-ax/ae-trafficlight)                                            | Application example which shows the usage of the [statemachine library](https://github.com/simatic-ax/statemachine).    |   |
+| [ae-json-library](https://github.com/simatic-ax/ae-json-library) | Application example which shows the usage of the [Json library](https://github.com/simatic-ax/json). |                              |   |

--- a/docs/overview/code-snippets.md
+++ b/docs/overview/code-snippets.md
@@ -1,0 +1,16 @@
+# Code-Snippets
+
+## Purpose
+
+Code-Snippets are intended to help the user to easily paste specific code-snippets into your files. We recommend to add the snippets-package(s) into your apax.yml - devDependencies. More code-snippets will be added here over time.
+
+These snippets can be used for:
+
+- include repeatable code-sections into your project fast
+- standardize sourcecode -behaviour/-creation
+
+## Overview of all Code-Snippets
+
+| Snippets Name | Description |
+|-|-|
+| [snippetscollection](https://github.com/simatic-ax/snippetscollection)            | Various useful snippets for ST like VarSection-, Class-, Methods- and Block-bodies as well as presets for creating Enums, IO's and AxUnit tests                      |

--- a/docs/overview/example-libraries.md
+++ b/docs/overview/example-libraries.md
@@ -1,0 +1,25 @@
+# Example Libraries
+
+## Purpose
+
+Here you'll find an overview about the example libraries you can find on our SIMATIC AX GitHub Community. 
+
+This example libraries can be used for:
+
+- usage in your own projects
+- get programming ideas for your own project
+- improve your programming skills regarding OOP with ST
+
+## Overview of all libraries
+
+| Library Name | Description | further resources |
+|-|-|-|
+| [simple-control-modules](https://github.com/simatic-ax/simple-control-modules)    | A collection of some simple control modules like encoder and counter.         |   |
+| [io](https://github.com/simatic-ax/io)                                            | Class collection for IO and signal handling for the most common data types    |   |
+| [collections](https://github.com/simatic-ax/collections)                          | Classes for list (FIFO/LIFO/LinkedList) handling                              |   |
+| [windowtracking](https://github.com/simatic-ax/windowtracking)                    | Useful library for positioning tracking on conveyor belts                     | [Appl. Example](https://github.com/simatic-ax/ae-sortingline) |
+| [json](https://github.com/simatic-ax/Json)                                        | This library provides support to parse or serialize JSON strings              | [Appl. Example](https://github.com/simatic-ax/ae-json-library)  |
+| [conversion](https://github.com/simatic-ax/conversion)                            | Convert AnyInt to ASCII, ASCII to AnyInt and some further conversions         |   |
+| [statemachine](https://github.com/simatic-ax/statemachine)                        | Library to create own state machine according the OOP state machine design pattern      |  [Appl. Example](https://github.com/simatic-ax/ae-sortingline)    |
+| [mocks](https://github.com/simatic-ax/mocks)                                      | Mocking is an important topic for unit testing with AX. This library contains some predefined mocks || 
+| [generators](https://github.com/simatic-ax/Generators) | Contains a pulse generator with a adjustable pulse, pause duration | |

--- a/docs/overview/templates.md
+++ b/docs/overview/templates.md
@@ -1,0 +1,20 @@
+# Useful templates for project workspaces
+
+## Purpose
+
+Here you'll find an overview about some useful templates for project workspaces you can find on our SIMATIC AX GitHub Community. Each project template contains workflow/project type specific definitions and scripts, so they don't have to be recreated each time.
+
+[More information regarding templates, you'll find here](https://console.prod.ax.siemens.cloud/docs/apax/templates)
+
+This templates can be used for:
+
+- own projects
+- base for new user defined templates
+
+## Overview of all templates
+
+| Template Name | Description |
+|-|-|
+| [template-ax2tia](https://github.com/simatic-ax/template-ax2tia)   | ProjectTemplate for an ax2tia workflow optimized workspace  |
+| [template-library](https://github.com/simatic-ax/template-library) | ProjectTemplate optimized for AX-library development  |
+| [template-app](https://github.com/simatic-ax/template-app) | ProjectTemplate optimized for AX-application creation   |

--- a/docs/overview/tutorials.md
+++ b/docs/overview/tutorials.md
@@ -1,0 +1,15 @@
+# Tutorials
+
+## Purpose
+
+Tutorials are intended to help the user to learn certain workflows in self-study. Here you will find an overview of the existing tutorials. More tutorials will be added here over time.
+
+This templates can be used for:
+
+- self-study of AX workflows
+
+## Overview of all tutorials
+
+| Tutorial Name | Description |
+|-|-|
+| [standardizer-tutorial-lib](https://github.com/simatic-ax/standardizer-tutorial-lib)   | This tutorial is specially designed for the AX standalone library developer. But ax2tia users will also find helpful tips and tricks for handling AX. |


### PR DESCRIPTION
Hi Jürgen ... I copied over the overview .md files from .github-private. 
There are no changes made to the content we would like to link to in these files. This propably has to be adopted preparing for some of your/the community content going public.
I would like to test if the estimated linking to the overview files (which I made in the SIOS FAQ) (regardless of its content) will work just fine.